### PR TITLE
Change default value of debug_log_entries to 15

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -307,7 +307,7 @@ class WebDriver extends CodeceptionModule implements
         'http_proxy_port'    => null,
         'ssl_proxy'          => null,
         'ssl_proxy_port'     => null,
-        'debug_log_entries'  => null,
+        'debug_log_entries'  => 15,
         'log_js_errors'      => false
     ];
 


### PR DESCRIPTION
15 is a documented default value, it looks like it was changed by accident
https://github.com/Codeception/module-webdriver/commit/559340e52616ed183f005dcc6253ced6cfcd4339#diff-b69c529efcc6368b5c564f8b36665a22R310

Fixes https://github.com/Codeception/Codeception/issues/5836