### PR TITLE
Fix cookie domain match

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3156,7 +3156,7 @@ class WebDriver extends CodeceptionModule implements
      */
     private function cookieDomainMatchesConfigUrl($cookie)
     {
-        if (!array_key_exists('domain', $cookie)) {
+        if (!isset($cookie['domain'])) {
             return true;
         }
 

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -677,17 +677,17 @@ class WebDriverTest extends TestsForBrowsers
         $fakeWdOptions = Stub::make('\Facebook\WebDriver\WebDriverOptions', [
             'getCookies' => Stub::atLeastOnce(function () {
                 return [
-                    [
+                    Cookie::createFromArray([
                         'name' => 'PHPSESSID',
                         'value' => '123456',
                         'path' => '/',
-                    ],
-                    [
+                    ]),
+                    Cookie::createFromArray([
                         'name' => '3rdParty',
                         'value' => '_value_',
                         'path' => '/',
                         'domain' => '.3rd-party.net',
-                    ],
+                    ])
                 ];
             }),
         ]);


### PR DESCRIPTION
`php-webdriver` changed the signature of `WebDriverOptions::getCookies` in v1.4.0. They attempted to keep it backwards-compatible, however it did result in some BC break.

`WebDriver::cookieDomainMatchesConfigUrl` continues to treat these values as arrays, however they are now objects that implement `ArrayAccess`. When calling:
```php
array_key_exists('domain', $cookie)
```
this returns false as it is not [ArrayAccess aware](https://www.php.net/manual/en/function.array-key-exists.php#refsect1-function.array-key-exists-notes). 

This means that using any version of php-webdriver greater than 1.3.0 will result in the rest of the function becoming unreachable.

Another serious problem is that 7.4 now raises a deprecation notice when calling `array_key_exists` on a non-array (and can be raised as an exception).

In the test case, I have modified it to create Cookie objects instead of arrays. https://github.com/Codeception/Codeception/pull/5480 reverted this, however the version constraint is now sufficient, `^1.6.0`.

In the method, I have opted to use `isset` instead, as the class convention is to continue treating it as an array, although this is deprecated.