### PR TITLE
Update switchToIFrame

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2521,32 +2521,39 @@ class WebDriver extends CodeceptionModule implements
      *
      * Example:
      * ``` html
-     * <iframe name="another_frame" src="http://example.com">
+     * <iframe name="another_frame" id="fr1" src="http://example.com">
      *
      * ```
      *
      * ``` php
      * <?php
-     * # switch to iframe
-     * $I->switchToIFrame("iframe[name='another_frame']");
+     * # switch to iframe by name
+     * $I->switchToIFrame("another_frame");
+     * # switch to iframe by CSS or XPath
+     * $I->switchToIFrame("#fr1");
      * # switch to parent page
      * $I->switchToIFrame();
      *
      * ```
      *
-     * @param string|null $cssOrXPath
+     * @param string|null $locator (name, CSS or XPath)
      */
-    public function switchToIFrame($cssOrXPath = null)
+    public function switchToIFrame($locator = null)
     {
-        if (is_null($cssOrXPath)) {
+        if (is_null($locator)) {
             $this->webDriver->switchTo()->defaultContent();
             return;
         }
-        $frames = $this->_findElements($cssOrXPath);
-        if (!count($frames)) {
-            throw $e;
+        try {
+            $els = $this->_findElements("iframe[name='$locator']");
+        } catch (\Exception $e) {
+            $this->debug('Iframe was not found by name, locating iframe by CSS or XPath');
+            $els = $this->_findElements($locator);
         }
-        $this->webDriver->switchTo()->frame($frames[0]);
+        if (!count($els)) {
+            throw new ElementNotFound($selector, "Iframe was not found by CSS or XPath");
+        }
+        $this->webDriver->switchTo()->frame($els[0]);
     }
 
     /**

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2528,30 +2528,25 @@ class WebDriver extends CodeceptionModule implements
      * ``` php
      * <?php
      * # switch to iframe
-     * $I->switchToIFrame("another_frame");
+     * $I->switchToIFrame("iframe[name='another_frame']");
      * # switch to parent page
      * $I->switchToIFrame();
      *
      * ```
      *
-     * @param string|null $name
+     * @param string|null $cssOrXPath
      */
-    public function switchToIFrame($name = null)
+    public function switchToIFrame($cssOrXPath = null)
     {
-        if (is_null($name)) {
+        if (is_null($cssOrXPath)) {
             $this->webDriver->switchTo()->defaultContent();
             return;
         }
-        try {
-            $this->webDriver->switchTo()->frame($name);
-        } catch (\Exception $e) {
-            $this->debug('Iframe was not found by name, locating iframe by CSS or XPath');
-            $frames = $this->_findElements($name);
-            if (!count($frames)) {
-                throw $e;
-            }
-            $this->webDriver->switchTo()->frame($frames[0]);
+        $frames = $this->_findElements($cssOrXPath);
+        if (!count($frames)) {
+            throw $e;
         }
+        $this->webDriver->switchTo()->frame($frames[0]);
     }
 
     /**


### PR DESCRIPTION
My test was OK previously and after a composer update they was KO:
- codeception/codeception (4.0.3 => 4.1.1)
- codeception/module-webdriver (1.0.1 => 1.0.3)
- php-webdriver/webdriver (1.7.1 => 1.8.1) 

I have an error when I use switchToIFrame with a name:
`$I->switchToIFrame("react-tinymce-0_ifr")`

Error: [InvalidArgumentException] In W3C compliance mode frame must be either instance of WebDriverElement, integer or null

