### PR TITLE
Removing string typehint

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3414,7 +3414,7 @@ class WebDriver extends CodeceptionModule implements
      *
      * @return string Converted string
      */
-    private static function xpathLiteral(string $s)
+    private static function xpathLiteral($s)
         {
             if (false === strpos($s, "'")) {
                 return sprintf("'%s'", $s);


### PR DESCRIPTION
This removes a typehint that is preventing this module from being run on php 5.6 when php 5.6 is supported in the composer.json