### PR TITLE
setCookie: don't add domain to cookie unless explicitly specified.

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -840,12 +840,7 @@ class WebDriver extends CodeceptionModule implements
         if (isset($params['expires'])) { // PhpBrowser compatibility
             $params['expiry'] = $params['expires'];
         }
-        if (!isset($params['domain'])) {
-            $urlParts = parse_url($this->config['url']);
-            if (isset($urlParts['host'])) {
-                $params['domain'] = $urlParts['host'];
-            }
-        }
+
         // #5401 Supply defaults, otherwise chromedriver 2.46 complains.
         $defaults = [
             'path' => '/',


### PR DESCRIPTION
Browsers fail with singlepart domain names, e.g. localhost.

After reading [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1488225#c7) I tried to remove the code which automatically adds domain name of configured site to all cookies and it seems to be working.
That code was added by [this commit](https://github.com/Codeception/module-webdriver/commit/6b1f4d6c8383f183f12e039f26e0107b93e6dfcf), probably to make it work with PhantomJS.

Fixes https://github.com/Codeception/Codeception/issues/5881