### PR TITLE
Add support for saving multi byte filename

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -509,7 +509,7 @@ class WebDriver extends CodeceptionModule implements
     public function _failed(TestInterface $test, $fail)
     {
         $this->debugWebDriverLogs($test);
-        $filename = preg_replace('~\W~', '.', Descriptor::getTestSignatureUnique($test));
+        $filename = preg_replace('~[^a-zA-Z0-9\x80-\xff]~', '.', Descriptor::getTestSignatureUnique($test));
         $outputDir = codecept_output_dir();
         $this->_saveScreenshot($report = $outputDir . mb_strcut($filename, 0, 245, 'utf-8') . '.fail.png');
         $test->getMetadata()->addReport('png', $report);


### PR DESCRIPTION
Hi

Add support for saving multi byte filename.

Before
![before](https://user-images.githubusercontent.com/1169171/89491222-b6a77100-d7e9-11ea-9133-af53e0b6bf14.PNG)

After
![after](https://user-images.githubusercontent.com/1169171/89491229-bb6c2500-d7e9-11ea-9e09-41f2ed758181.PNG)
