### PR TITLE
Update WebDriver.php

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -49,18 +49,24 @@ use Facebook\WebDriver\WebDriverKeys;
 use Facebook\WebDriver\WebDriverSelect;
 
 /**
- * New generation Selenium WebDriver module.
+ * Run tests in real browsers using the W3C [WebDriver protocol](https://www.w3.org/TR/webdriver/).
  *
  * ## Local Testing
+ *
+ * ### Browsers: Chrome and/or Firefox
+ *
+ * First, you need to install the browser itself: Chrome and/or Firefox.
+ * * To run tests in Chrome/Chromium, you need to install [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/getting-started).
+ * * To use Firefox, install [GeckoDriver](https://github.com/mozilla/geckodriver).
+ * If you want to use both, consider setting up a dedicated [Codeception environment](https://codeception.com/docs/07-AdvancedUsage#Environments) for each.
  *
  * ### Selenium
  *
  * To run Selenium Server you need [Java](https://www.java.com/) as well as Chrome or Firefox browser installed.
  *
  * 1. Download [Selenium Standalone Server](http://docs.seleniumhq.org/download/)
- * 2. To use Chrome, install [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/getting-started). To use Firefox, install [GeckoDriver](https://github.com/mozilla/geckodriver).
- * 3. Launch the Selenium Server: `java -jar selenium-server-standalone-3.xx.xxx.jar`. To locate Chromedriver binary use `-Dwebdriver.chrome.driver=./chromedriver` option. For Geckodriver use `-Dwebdriver.gecko.driver=./geckodriver`.
- * 4. Configure this module (in `acceptance.suite.yml`) by setting `url` and `browser`:
+ * 2. Launch the Selenium Server: `java -jar selenium-server-standalone-3.xx.xxx.jar`. To locate Chromedriver binary use `-Dwebdriver.chrome.driver=./chromedriver` option. For Geckodriver use `-Dwebdriver.gecko.driver=./geckodriver`.
+ * 3. Configure this module (in `acceptance.suite.yml`) by setting `url` and `browser`:
  *
  * ```yaml
  *     modules:


### PR DESCRIPTION
Reorganizing the docs about setup. First step of what I suggested at https://github.com/Codeception/module-webdriver/pull/30#issuecomment-720152810

Once you've merged all my 3 PR's from today, please rebuild the page https://codeception.com/docs/modules/WebDriver, so I can see what this looks like so far.

Questions:
* "Note that Selenium 3.8 renamed this capability from chromeOptions to goog:chromeOptions" This obviously only applies when using Selenium - i.e. when using ChromeDriver directly, it's still `chromeOptions`?
* Depending on what you answer at https://github.com/Codeception/module-webdriver/issues/28#issuecomment-720143799, I would suggest: Tell people to start without Selenium, and see how far they'll get. Reason: Selenium installation is cumbersome, and might not be necessary. So I'd like to "sell" Selenium as (a) tool for troubleshooting if they run into problems, and (b) power tool giving additional options (which?).

Next step (depending on how much time I have :-)
I'd like to shorten https://codeception.com/docs/03-AcceptanceTests#WebDriver:
* Remove everything that's already present here (e.g. installation instructions)
* The "Acceptance Tests" page should be an **overview** page for new users, showcasing Codeception's cool features. Configuration details (like e.g. the lengthy SmartWait examples) don't belong there, and should be moved to the WebDriver module page.