### PR TITLE
Select only necessary fields for submitForm()

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2427,7 +2427,7 @@ class WebDriver extends CodeceptionModule implements
         $form = $this->matchFirstOrFail($this->getBaseElement(), $selector);
 
         $fields = $form->findElements(
-            WebDriverBy::cssSelector('input:enabled,textarea:enabled,select:enabled,input[type=hidden]')
+            WebDriverBy::cssSelector('input:enabled[name],textarea:enabled[name],select:enabled[name],input[type=hidden][name]')
         );
         foreach ($fields as $field) {
             $fieldName = $this->getSubmissionFormFieldName($field->getAttribute('name'));


### PR DESCRIPTION
This changes the selector of fields used in `submitForm()` to get only
fields with a `name` attribute.

Fixes: #83