### PR TITLE
Fixing typehint

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -2620,10 +2620,11 @@ class WebDriver extends CodeceptionModule implements
      * $I->waitForText('foo', 30, '.title'); // secs
      * ```
      *
-     * @param int $timeout seconds
+     * @param ?int $timeout seconds
+     * @param ?string|?string[] $selector
      * @throws Exception
      */
-    public function waitForText(string $text, int $timeout = 10, string $selector = null): void
+    public function waitForText(string $text, ?int $timeout = 10, ?mixed $selector = null): void
     {
         $message = sprintf(
             'Waited for %d secs but text %s still not found',


### PR DESCRIPTION
See https://github.com/Codeception/module-webdriver/pull/82#issuecomment-997427904
Since `string|string[]` is not allowed in PHP 7.4, I added it as docblock. Also added `?`, but I'm not sure if `?string|?string[]` is right.