### PR TITLE
Avoid TypeError in preg_match()

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1971,7 +1971,10 @@ class WebDriver extends CodeceptionModule implements
             return $els[0]->getText();
         }
 
-        if (@preg_match($cssOrXPathOrRegex, $this->webDriver->getPageSource(), $matches)) {
+        if (
+            is_string($cssOrXPathOrRegex)
+            && @preg_match($cssOrXPathOrRegex, $this->webDriver->getPageSource(), $matches)
+        ) {
             return $matches[1];
         }
 

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -706,6 +706,19 @@ abstract class TestsForWeb extends Unit
         $this->assertSame('test', $result);
     }
 
+    public function testGrabTextFromWithArraySelectorForExistingElement()
+    {
+        $this->module->amOnPage('/');
+        $this->assertSame('More info', $this->module->grabTextFrom(['id' => 'link']));
+    }
+
+    public function testGrabTextFromWithArraySelectorForNonExistentElement()
+    {
+        $this->module->amOnPage('/');
+        $this->expectException('Codeception\Exception\ElementNotFound');
+        $this->module->grabTextFrom(['id' => 'unknown_link']);
+    }
+
     public function testGrabValueFrom()
     {
         $this->module->amOnPage('/form/hidden');


### PR DESCRIPTION
Using non-string locator in grabTextFrom() leads to "[TypeError] preg_match() expects parameter 1 to be string, array given" error. This error appeared after adding strict types declaration to src/Codeception/Module/WebDriver.php.