### PR TITLE
[module-webdriver] fix type error in PHP 8.1 when converting ms to sec

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -698,7 +698,7 @@ class WebDriver extends CodeceptionModule implements
 
         foreach ($logEntries as $logEntry) {
             // Timestamp is in milliseconds, but date() requires seconds.
-            $time = date('H:i:s', (int) floor($logEntry['timestamp'] / 1000)) .
+            $time = date('H:i:s', intval($logEntry['timestamp'] / 1000)) .
                 // Append the milliseconds to the end of the time string
                 '.' . ($logEntry['timestamp'] % 1000);
             $formattedLogs .= "{$time} {$logEntry['level']} - {$logEntry['message']}\n";
@@ -718,7 +718,7 @@ class WebDriver extends CodeceptionModule implements
                 && $this->isJSError($logEntry['level'], $logEntry['message'])
             ) {
                 // Timestamp is in milliseconds, but date() requires seconds.
-                $time = date('H:i:s', (int) floor($logEntry['timestamp'] / 1000)) .
+                $time = date('H:i:s', intval($logEntry['timestamp'] / 1000)) .
                     // Append the milliseconds to the end of the time string
                     '.' . ($logEntry['timestamp'] % 1000);
                 $test->getScenario()->comment("{$time} {$logEntry['level']} - {$logEntry['message']}");

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -698,7 +698,7 @@ class WebDriver extends CodeceptionModule implements
 
         foreach ($logEntries as $logEntry) {
             // Timestamp is in milliseconds, but date() requires seconds.
-            $time = date('H:i:s', $logEntry['timestamp'] / 1000) .
+            $time = date('H:i:s', (int) floor($logEntry['timestamp'] / 1000)) .
                 // Append the milliseconds to the end of the time string
                 '.' . ($logEntry['timestamp'] % 1000);
             $formattedLogs .= "{$time} {$logEntry['level']} - {$logEntry['message']}\n";
@@ -718,7 +718,7 @@ class WebDriver extends CodeceptionModule implements
                 && $this->isJSError($logEntry['level'], $logEntry['message'])
             ) {
                 // Timestamp is in milliseconds, but date() requires seconds.
-                $time = date('H:i:s', $logEntry['timestamp'] / 1000) .
+                $time = date('H:i:s', (int) floor($logEntry['timestamp'] / 1000)) .
                     // Append the milliseconds to the end of the time string
                     '.' . ($logEntry['timestamp'] % 1000);
                 $test->getScenario()->comment("{$time} {$logEntry['level']} - {$logEntry['message']}");


### PR DESCRIPTION
fixes ![102](https://github.com/Codeception/module-webdriver/issues/102)

```
php -v
PHP 8.1.8 (cli) (built: Jul 11 2022 08:53:35) (NTS)
---
TypeError date(): Argument #2 ($timestamp) must be of type ?int, float given
TypeError Uncaught \TypeError

TypeError at /xxx/vendor/codeception/module-webdriver/src/Codeception/Module/WebDriver.php:721

```

Fixes a type error when calling `date` function with a float while formatting log entries:



