### PR TITLE
WebDriver Doc: Added missing Docker parameter

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -106,7 +106,7 @@ use PHPUnit\Framework\SelfDescribing;
  * Running tests inside Docker is as easy as pulling [official selenium image](https://github.com/SeleniumHQ/docker-selenium) and starting a container with Chrome:
  *
  * ```
- * docker run --net=host selenium/standalone-chrome
+ * docker run --net=host --shm-size 2g selenium/standalone-chrome
  * ```
  *
  * By using `--net=host` allow Selenium to access local websites.


### PR DESCRIPTION
"When executing docker run for an image that contains a browser please use the flag --shm-size=2g to use the host's shared memory."
Ref: https://github.com/SeleniumHQ/docker-selenium#quick-start