### PR TITLE
Negative tab offset crashes

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3527,9 +3527,12 @@ class WebDriver extends CodeceptionModule implements
      */
     public function closeTab(): void
     {
+        $currentTab = $this->webDriver->getWindowHandle();
         $prevTab = $this->getRelativeTabHandle(-1);
         $this->webDriver->close();
-        $this->webDriver->switchTo()->window($prevTab);
+        if ($prevTab !== $currentTab) {
+            $this->webDriver->switchTo()->window($prevTab);
+        }
     }
 
     /**

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3529,10 +3529,11 @@ class WebDriver extends CodeceptionModule implements
     {
         $currentTab = $this->webDriver->getWindowHandle();
         $prevTab = $this->getRelativeTabHandle(-1);
-        $this->webDriver->close();
-        if ($prevTab !== $currentTab) {
-            $this->webDriver->switchTo()->window($prevTab);
+        if ($prevTab === $currentTab) {
+            throw new ModuleException($this, 'Will not close the last open tab');
         }
+        $this->webDriver->close();
+        $this->webDriver->switchTo()->window($prevTab);
     }
 
     /**

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3575,8 +3575,12 @@ class WebDriver extends CodeceptionModule implements
 
         $handle = $this->webDriver->getWindowHandle();
         $handles = $this->webDriver->getWindowHandles();
-        $idx = array_search($handle, $handles);
-        return $handles[($idx + $offset) % count($handles)];
+        $currentHandleIdx = array_search($handle, $handles);
+        $newHandleIdx = ($currentHandleIdx + $offset) % count($handles);
+        if ($newHandleIdx < 0) {
+            $newHandleIdx = count($handles) + $newHandleIdx;
+        }
+        return $handles[$newHandleIdx];
     }
 
     /**

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -1025,6 +1025,10 @@ final class WebDriverTest extends TestsForBrowsers
         $this->module->switchToNextTab(2);
         $this->module->seeInCurrentUrl('example1');
         $this->module->seeNumberOfTabs(3);
+        $this->module->closeTab();
+        $this->module->seeNumberOfTabs(2);
+        $this->module->closeTab();
+        $this->module->closeTab();
     }
 
     public function testPerformOnWithArray()

--- a/tests/web/WebDriverTest.php
+++ b/tests/web/WebDriverTest.php
@@ -1028,7 +1028,6 @@ final class WebDriverTest extends TestsForBrowsers
         $this->module->closeTab();
         $this->module->seeNumberOfTabs(2);
         $this->module->closeTab();
-        $this->module->closeTab();
     }
 
     public function testPerformOnWithArray()


### PR DESCRIPTION
Two things:
* Fix a bug when the current tab (window handle) is the first in the list, the previous handle is accessed via key `-1`, which doesn't exist.
* Prevent closing the last tab, it will destroy the selenium session (most likely unintentionally).