### PR TITLE
Fix namespace mismatch of ActionSequence

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3633,7 +3633,7 @@ class WebDriver extends CodeceptionModule implements
      * In 3rd argument you can set number a seconds to wait for element to appear
      *
      * @param string|array|WebDriverBy $element
-     * @param callable|array|ActionSequence $actions
+     * @param callable|array|\Codeception\Util\ActionSequence $actions
      */
     public function performOn($element, $actions, int $timeout = 10): void
     {


### PR DESCRIPTION
Module methods are copied into a generated trait which does not have any imports. Thus the generated namespace of the trait was used for the "ActionSequence" class. This did not match the actual namespace of that class. Fix this by using a FQCN instead.

Example error visible in VisualStudio Code:

> Argument '2' passed to performOn() is expected to be of type Tests\Support\_generated\ActionSequence|array|callable, Codeception\Util\ActionSequence given