### PR TITLE
Fix type error when using `seeLink`

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -1367,7 +1367,7 @@ class WebDriver extends CodeceptionModule implements
         return array_filter(
             $nodes,
             function (WebDriverElement $e) use ($expectedUrl, $absoluteCurrentUrl): bool {
-                $elementHref = Uri::mergeUrls($absoluteCurrentUrl, $e->getAttribute('href'));
+                $elementHref = Uri::mergeUrls($absoluteCurrentUrl, $e->getAttribute('href') ?? '');
                 return $elementHref === $expectedUrl;
             }
         );


### PR DESCRIPTION
Resolves a type error when using `seeLink` due to `WebDriverElement::getAttribute()` being able to return null which is not allowed in `Uri::mergeUrls`