### PR TITLE
Fix WebDriver connection exception handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "codeception/codeception": "^5.0.8",
         "codeception/lib-web": "^1.0.1",
         "codeception/stub": "^4.0",
-        "php-webdriver/webdriver": "^1.8.0",
+        "php-webdriver/webdriver": "^1.14.0",
         "phpunit/phpunit": "^10.0 || ^11.0"
     },
     "suggest": {

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -35,11 +35,11 @@ use Codeception\Util\Uri;
 use Exception;
 use Facebook\WebDriver\Cookie;
 use Facebook\WebDriver\Cookie as WebDriverCookie;
+use Facebook\WebDriver\Exception\Internal\UnexpectedResponseException;
 use Facebook\WebDriver\Exception\InvalidElementStateException;
 use Facebook\WebDriver\Exception\InvalidSelectorException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Exception\UnknownErrorException;
-use Facebook\WebDriver\Exception\WebDriverCurlException;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\Remote\LocalFileDetector;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
@@ -1688,7 +1688,7 @@ class WebDriver extends CodeceptionModule implements
 
             $this->setBaseElement();
             $this->initialWindowSize();
-        } catch (WebDriverCurlException $exception) {
+        } catch (UnexpectedResponseException $exception) {
             codecept_debug('Curl error: ' . $exception->getMessage());
             throw new ConnectionException(
                 "Can't connect to WebDriver at {$this->wdHost}."


### PR DESCRIPTION
WebDriverCurlException was moved to Internal namespace and deprecated in php-webdriver/webdriver 1.14