### PR TITLE
`pressKey`: Fixing `@param string|array<string|string> $chars`

### DIFF
--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3149,22 +3149,22 @@ class WebDriver extends CodeceptionModule implements
 
     /**
      * Presses the given key on the given element.
-     * To specify a character and modifier (e.g. <kbd>Ctrl</kbd>, Alt, Shift, Meta), pass an array for `$char` with
+     * To specify a character and modifier (e.g. <kbd>Ctrl</kbd>, <kbd>Alt</kbd>, <kbd>Shift</kbd>, <kbd>Meta</kbd>), pass an array for `$char` with
      * the modifier as the first element and the character as the second.
-     * For special keys, use the constants from [`Facebook\WebDriver\WebDriverKeys`](https://github.com/php-webdriver/php-webdriver/blob/main/lib/WebDriverKeys.php).
+     * For special keys, use the constants from [Facebook\WebDriver\WebDriverKeys](https://github.com/php-webdriver/php-webdriver/blob/main/lib/WebDriverKeys.php).
      *
      * ``` php
      * <?php
      * // <input id="page" value="old">
      * $I->pressKey('#page', 'a'); // => olda
-     * $I->pressKey('#page', ['ctrl', 'a'],'new'); //=> new
-     * $I->pressKey('#page', ['shift', '111'],'1','x'); //=> old!!!1x
-     * $I->pressKey('descendant-or-self::*[@id='page']','u'); //=> oldu
-     * $I->pressKey('#name', ['ctrl', 'a'], \Facebook\WebDriver\WebDriverKeys::DELETE); //=>''
+     * $I->pressKey('#page', ['ctrl', 'a'],'new'); // => new
+     * $I->pressKey('#page', ['shift', '111'], '1', 'x'); // => old!!!1x
+     * $I->pressKey('descendant-or-self::*[@id='page']', 'u'); // => oldu
+     * $I->pressKey('#name', ['ctrl', 'a'], \Facebook\WebDriver\WebDriverKeys::DELETE); // =>''
      * ```
      *
      * @param string|array|WebDriverBy $element
-     * @param array<string|string[]>$chars Can be char or array with modifier. You can provide several chars.
+     * @param string|array<string|string> $chars Can be char or array with modifier. You can provide several chars.
      * @throws ElementNotFound
      */
     public function pressKey($element, ...$chars): void

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3164,7 +3164,7 @@ class WebDriver extends CodeceptionModule implements
      * ```
      *
      * @param string|array|WebDriverBy $element
-     * @param string|list<string> $chars Can be char or array with modifier. You can provide several chars.
+     * @param string|array<string, string> $chars Can be char or array with modifier. You can provide several chars.
      * @throws ElementNotFound
      */
     public function pressKey($element, ...$chars): void

--- a/src/Codeception/Module/WebDriver.php
+++ b/src/Codeception/Module/WebDriver.php
@@ -3164,7 +3164,7 @@ class WebDriver extends CodeceptionModule implements
      * ```
      *
      * @param string|array|WebDriverBy $element
-     * @param string|array<string|string> $chars Can be char or array with modifier. You can provide several chars.
+     * @param string|list<string> $chars Can be char or array with modifier. You can provide several chars.
      * @throws ElementNotFound
      */
     public function pressKey($element, ...$chars): void


### PR DESCRIPTION
The docblock was changed in https://github.com/Codeception/module-webdriver/pull/88, and was probably intended to be `string|string[]`