### PR TITLE
Fix PHP 8.4 deprecation for E_STRICT constant

### DIFF
--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,5 +1,5 @@
 # Codeception Test Suite Configuration
 
 # suite for unit (internal) tests.
-error_level: "E_ALL | E_STRICT"
+error_level: "E_ALL"
 class_name: UnitTester


### PR DESCRIPTION
The constant is deprecated: https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant