### PR TITLE
Support PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "codeception/lib-web": "^1.0.1",
         "codeception/stub": "^4.0",
         "php-webdriver/webdriver": "^1.14.0",
-        "phpunit/phpunit": "^10.0 || ^11.0"
+        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0"
     },
     "suggest": {
         "codeception/phpbuiltinserver": "Start and stop PHP built-in web server for your tests"


### PR DESCRIPTION
The only classes from phpunit which are directly used by this package are:
* `PHPUnit\Framework\AssertionFailedError`
* `PHPUnit\Framework\ExpectationFailedException`
* `PHPUnit\Framework\SelfDescribing`

These classes don't seem to be affected by the BC breaking changes in PHPUnit 12.

Please note: currently, PHPUnit 12 is not installable because some other direct dependencies do not support it yet:
* `codeception/codeception`
* `codeception/lib-web` (fixed in https://github.com/Codeception/lib-web/pull/14)
* `codeception/Stub` (fixed in https://github.com/Codeception/Stub/pull/50)